### PR TITLE
Update cantaloupe.properties

### DIFF
--- a/config/cantaloupe.properties
+++ b/config/cantaloupe.properties
@@ -158,7 +158,7 @@ FilesystemSource.BasicLookupStrategy.path_prefix = /images/
 
 # Server-side path or extension that will be suffixed to the identifier in
 # the URL.
-FilesystemSource.BasicLookupStrategy.path_suffix =
+FilesystemSource.BasicLookupStrategy.path_suffix =.tif 
 
 #----------------------------------------
 # HttpSource
@@ -291,11 +291,11 @@ AzureStorageSource.chunking.cache.max_size = 5M
 # the classpath; see the user manual.
 
 # !!
-JdbcSource.url = jdbc:postgresql://localhost:5432/my_database
+JdbcSource.url = 
 # !!
-JdbcSource.user = postgres
+JdbcSource.user = 
 # !!
-JdbcSource.password = postgres
+JdbcSource.password = 
 
 # !! Connection timeout in seconds.
 JdbcSource.connection_timeout = 10
@@ -686,7 +686,7 @@ overlays.BasicStrategy.output_height_threshold = 300
 #----------------------------------------
 
 # `trace`, `debug`, `info`, `warn`, `error`, `all`, or `off`
-log.application.level = debug
+log.application.level = error
 
 log.application.ConsoleAppender.enabled = true
 log.application.ConsoleAppender.logstash.enabled = false
@@ -720,7 +720,7 @@ log.application.SyslogAppender.facility = LOCAL0
 # N.B.: Don't enable FileAppender and RollingFileAppender simultaneously!
 log.error.FileAppender.enabled = false
 log.error.FileAppender.logstash.enabled = false
-log.error.FileAppender.pathname = /path/to/logs/error.log
+log.error.FileAppender.pathname = /logs/error.log
 
 log.error.RollingFileAppender.enabled = false
 log.error.RollingFileAppender.logstash.enabled = false
@@ -733,7 +733,7 @@ log.error.RollingFileAppender.TimeBasedRollingPolicy.max_history = 30
 # Access Log
 #----------------------------------------
 
-log.access.ConsoleAppender.enabled = false
+log.access.ConsoleAppender.enabled = true 
 
 # N.B.: Don't enable FileAppender and RollingFileAppender simultaneously!
 log.access.FileAppender.enabled = false


### PR DESCRIPTION
Changing the basic config for cantaloupe:  

- add `.tif`as default 
- remove configuration or Postgres for delegate script
- set log level to `error` instead of `debug`
- enable `log.access.ConsoleAppender`