### PR TITLE
Update cache behaviour 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
+cache/
+data/
 images/*.*
 !images/.gitkeep
-data/
 scripts/to_db_*.csv

--- a/config/cantaloupe.properties
+++ b/config/cantaloupe.properties
@@ -475,11 +475,11 @@ cache.server.source = FilesystemCache
 cache.server.source.ttl_seconds = 2592000
 
 # Enables the derivative (processed image) cache.
-cache.server.derivative.enabled = false
+cache.server.derivative.enabled = true
 
 # Available values are `FilesystemCache`, `JdbcCache`, `RedisCache`,
 # `HeapCache`, `S3Cache`, and `AzureStorageCache`.
-cache.server.derivative =
+cache.server.derivative = FilesystemCache
 
 # Amount of time derivative cache content remains valid. Set to blank or 0
 # for forever.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
         image: swissartresearx/cantaloupe:5.0
         restart: always
         volumes:
+            - ./cache:/var/cache/cantaloupe
             - ./config:/config
             - ./images:/images
     jobs:


### PR DESCRIPTION
Hi @fkraeutli 

I have updated the configuration regarding the cache. Could you have a look and merge if ok? 

NB: the purpose of the cache in the GRP project, IMHO, should be to cache the derivates (i.e. thumbnails, caching the .tifs could explode disk usage beyond reasonable). If you happen to know of a better option to do so, please feel free to make any changes.

Thx, Th. 